### PR TITLE
Update api request error msg

### DIFF
--- a/pyvyos/device.py
+++ b/pyvyos/device.py
@@ -141,9 +141,8 @@ class VyDevice:
         }
 
         return payload
-
         
-        def _api_request(self, command, op, path=[], method='POST', file=None, url=None, name=None):
+    def _api_request(self, command, op, path=[], method='POST', file=None, url=None, name=None):
         """
         Make an API request.
 
@@ -161,6 +160,7 @@ class VyDevice:
         """
         url = self._get_url(command)
         payload = self._get_payload(op, path=path, file=file, url=url, name=name)
+
         headers = {}
         error = False      
         result = {}
@@ -169,7 +169,7 @@ class VyDevice:
             resp = requests.post(url, verify=self.verify, data=payload, timeout=self.timeout, headers=headers)
             resp_decoded = resp.json()
 
-            if resp_decoded['success'] == True:
+            if resp_decoded['success']:
                 result = resp_decoded['data']
                 error = False
             else:

--- a/pyvyos/device.py
+++ b/pyvyos/device.py
@@ -142,6 +142,7 @@ class VyDevice:
 
         return payload
 
+        
         def _api_request(self, command, op, path=[], method='POST', file=None, url=None, name=None):
         """
         Make an API request.
@@ -160,7 +161,6 @@ class VyDevice:
         """
         url = self._get_url(command)
         payload = self._get_payload(op, path=path, file=file, url=url, name=name)
-
         headers = {}
         error = False      
         result = {}

--- a/pyvyos/device.py
+++ b/pyvyos/device.py
@@ -177,7 +177,7 @@ class VyDevice:
 
             status = resp.status_code
 
-        except requests.exceptions.ConnectionError | json.JSONDecodeError as e:
+        except (requests.exceptions.ConnectionError, json.JSONDecodeError) as e:
             error = 'Error: ' + str(e)
             status = 0
 


### PR DESCRIPTION
Issue:
- When `response.status == 400`, the error message is hard coded to `http error`.

Solution:
- Modified `def _api_request` to ensure the function returns a proper error message.